### PR TITLE
Removing deny from policy names and bindings + adding timestamp to alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ helm install kubeenforcer -n kubescape ./charts/kubeenforcer
 ### Installing Polices
 *Example polices 🚧*
 ```bash
-kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/download/v0.8/policy-configuration-definition.yaml
-kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/download/v0.8/basic-control-configuration.yaml
-kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/download/v0.8/kubescape-validating-admission-policies-x-v1alpha1.yaml
+kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/latest/download/policy-configuration-definition.yaml
+kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/latest/download/basic-control-configuration.yaml
+kubectl apply -f https://github.com/kubescape/cel-admission-library/releases/latest/download/kubescape-validating-admission-policies-x-v1alpha1.yaml
 ```
 
 ### Installing Policy Bindings

--- a/pkg/alertmanager/client.go
+++ b/pkg/alertmanager/client.go
@@ -55,6 +55,7 @@ func (alertmanager *AlertManager) createAlert(alertInfo *AlertInfo) *models.Post
 				"instance":        alertInfo.Instance,
 				"namespace":       alertInfo.Namespace,
 				"requesting_user": alertInfo.RequestingUser,
+				"timestamp":       alertInfo.Timestamp,
 			},
 		},
 		StartsAt: strfmt.DateTime(time.Now().UTC()),

--- a/pkg/alertmanager/types.go
+++ b/pkg/alertmanager/types.go
@@ -8,4 +8,5 @@ type AlertInfo struct {
 	Description    string
 	Namespace      string
 	RequestingUser string
+	Timestamp      string
 }

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -449,6 +449,7 @@ func reviewResponse(uid types.UID, err error, aletmanagerHost string, resource s
 				Instance:       name,
 				Namespace:      namespace,
 				RequestingUser: requestingUser.Username,
+				Timestamp:      time.Now().String(),
 				Description:    getMessage(attrs),
 			}
 			alerter.Alert(&alertInfo)

--- a/policies-bindings/attach/binding.yaml
+++ b/policies-bindings/attach/binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: admissionregistration.x-k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: cluster-policy-deny-attach-binding
+  name: cluster-policy-attach-binding
 spec:
-  policyName: cluster-policy-deny-attach
+  policyName: cluster-policy-attach
   validationActions:
   - Audit

--- a/policies-bindings/exec/binding.yaml
+++ b/policies-bindings/exec/binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: admissionregistration.x-k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: cluster-policy-deny-exec-binding
+  name: cluster-policy-exec-binding
 spec:
-  policyName: cluster-policy-deny-exec
+  policyName: cluster-policy-exec
   validationActions:
   - Audit

--- a/policies-bindings/hostmount/binding.yaml
+++ b/policies-bindings/hostmount/binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: admissionregistration.x-k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: cluster-policy-deny-host-mount-binding
+  name: cluster-policy-host-mount-binding
 spec:
-  policyName: cluster-policy-deny-host-mount
+  policyName: cluster-policy-host-mount
   validationActions:
   - Audit

--- a/policies-bindings/insecure-capabilities/binding.yaml
+++ b/policies-bindings/insecure-capabilities/binding.yaml
@@ -1,9 +1,9 @@
 apiVersion: admissionregistration.x-k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: cluster-policy-deny-insecure-capabilities-binding
+  name: cluster-policy-insecure-capabilities-binding
 spec:
-  policyName: cluster-policy-deny-insecure-capabilities
+  policyName: cluster-policy-insecure-capabilities
   paramRef:
     name: basic-control-configuration
   validationActions:

--- a/policies-bindings/portforward/binding.yaml
+++ b/policies-bindings/portforward/binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: admissionregistration.x-k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: cluster-policy-deny-portforward-binding
+  name: cluster-policy-portforward-binding
 spec:
-  policyName: cluster-policy-deny-portforward
+  policyName: cluster-policy-portforward
   validationActions:
   - Audit

--- a/policies-bindings/privileged/binding.yaml
+++ b/policies-bindings/privileged/binding.yaml
@@ -1,8 +1,8 @@
 apiVersion: admissionregistration.x-k8s.io/v1alpha1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
-  name: cluster-policy-deny-privileged-flag-binding
+  name: cluster-policy-privileged-flag-binding
 spec:
-  policyName: cluster-policy-deny-priviliged-flag
+  policyName: cluster-policy-priviliged-flag
   validationActions:
   - Audit


### PR DESCRIPTION
Merge only when https://github.com/kubescape/cel-admission-library/pull/51 is merged and released.